### PR TITLE
use kraken default etcd version

### DIFF
--- a/maas.yaml
+++ b/maas.yaml
@@ -159,7 +159,7 @@ definitions:
       clientPorts: [2379, 4001]
       peerPorts: [2380]
       ssl: true
-      version: v3.2.5
+      version: v3.0.17
     - &defaultEtcdEvents
       name: etcdEvents
       kind: kvStore
@@ -168,7 +168,7 @@ definitions:
       clientPorts: [2381]
       peerPorts: [2382]
       ssl: true
-      version: v3.2.5
+      version: v3.0.17
 
   apiServerConfigs:
     - &defaultApiServer


### PR DESCRIPTION
use a version of etcd that doesn't explode with a fd exhaustion after 2 days.